### PR TITLE
Fix column header responsiveness bug.

### DIFF
--- a/scripts/main-built.js
+++ b/scripts/main-built.js
@@ -154,23 +154,24 @@ function refreshLegislatorFilters() {
  * Applies approriate table formatting for the current Browser size.
  */
 function formatTableForBrowserSize() {
-  // if the table is displayed
-  if($('#search-results').css('display') != 'none'){
-    // get whether this is for mobile or not
-    if($(window).width() <= SMALL_BREAKPOINT){
-      $('.district-cell, .election-cell').hide();
-      $('.results-cell > p:nth-child(2)').show();
-      $('button.results-cell').html('\>');
-    } else if(SMALL_BREAKPOINT < $(window).width() && $(window).width() <= MID_BREAKPOINT){
-      $('#score-header').html('CC SCORE');
-      $('#election-header').html('LAST PRES. RESULT');
-      $('.district-cell, .election-cell').show();
-      $('.results-cell > p:nth-child(2)').hide();
-      $('button.results-cell').html('TAKE ACTION');
-    } else {
-      $('#score-header').html('CLIMATE CABINET SCORE');
-      $('#election-header').html('LAST PRESIDENTIAL RESULT');
-    }
+  // apply small breakpoint changes
+  if($(window).width() <= SMALL_BREAKPOINT){
+    $('button.results-cell').html('\>');
+    $('.district-cell, .election-cell').hide();
+    $('.results-cell > p:nth-child(2)').show();
+  } else {
+    $('button.results-cell').html('TAKE ACTION');
+    $('.district-cell, .election-cell').show();
+    $('.results-cell > p:nth-child(2)').hide();
+  }
+
+  // apply mid breakpoint changes
+  if($(window).width() <= MID_BREAKPOINT){
+    $('#score-header').html('CC SCORE');
+    $('#election-header').html('LAST PRES. RESULT');
+  } else {
+    $('#score-header').html('CLIMATE CABINET SCORE');
+    $('#election-header').html('LAST PRESIDENTIAL RESULT');
   }
 }
 
@@ -419,4 +420,7 @@ $(document).ready(async function(){
     // call handle state selection
     handleStateSelection();
   }
+
+  // make sure the UI loads according to browser size
+  formatTableForBrowserSize();
 });

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -154,23 +154,24 @@ function refreshLegislatorFilters() {
  * Applies approriate table formatting for the current Browser size.
  */
 function formatTableForBrowserSize() {
-  // if the table is displayed
-  if($('#search-results').css('display') != 'none'){
-    // get whether this is for mobile or not
-    if($(window).width() <= SMALL_BREAKPOINT){
-      $('.district-cell, .election-cell').hide();
-      $('.results-cell > p:nth-child(2)').show();
-      $('button.results-cell').html('\>');
-    } else if(SMALL_BREAKPOINT < $(window).width() && $(window).width() <= MID_BREAKPOINT){
-      $('#score-header').html('CC SCORE');
-      $('#election-header').html('LAST PRES. RESULT');
-      $('.district-cell, .election-cell').show();
-      $('.results-cell > p:nth-child(2)').hide();
-      $('button.results-cell').html('TAKE ACTION');
-    } else {
-      $('#score-header').html('CLIMATE CABINET SCORE');
-      $('#election-header').html('LAST PRESIDENTIAL RESULT');
-    }
+  // apply small breakpoint changes
+  if($(window).width() <= SMALL_BREAKPOINT){
+    $('button.results-cell').html('\>');
+    $('.district-cell, .election-cell').hide();
+    $('.results-cell > p:nth-child(2)').show();
+  } else {
+    $('button.results-cell').html('TAKE ACTION');
+    $('.district-cell, .election-cell').show();
+    $('.results-cell > p:nth-child(2)').hide();
+  }
+
+  // apply mid breakpoint changes
+  if($(window).width() <= MID_BREAKPOINT){
+    $('#score-header').html('CC SCORE');
+    $('#election-header').html('LAST PRES. RESULT');
+  } else {
+    $('#score-header').html('CLIMATE CABINET SCORE');
+    $('#election-header').html('LAST PRESIDENTIAL RESULT');
   }
 }
 
@@ -419,4 +420,7 @@ $(document).ready(async function(){
     // call handle state selection
     handleStateSelection();
   }
+
+  // make sure the UI loads according to browser size
+  formatTableForBrowserSize();
 });


### PR DESCRIPTION
When the search app was loading on mobile, the columns were not loading with their correct initial value. Specifically, the column containing scores was loading in as "Climate Cabinet Score" instead of "CC Score" as desired. The function `formatTableForBrowserSize` was refactor to make this fix.