### PR TITLE
Filter District drop-down menu based on Chamber drop-down selection.

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,9 @@
         </select>
         <select name="chamber" id="chamber-input" class="search-input" disabled>
           <option value="" selected="selected" hidden="hidden">Select Chamber</option>
-          <!-- <option value="" selected="selected">any chamber</option> -->
         </select>
         <select name="district" id="district-input" class="search-input" disabled>
           <option value="" selected="selected" hidden="hidden">Select District Number</option>
-          <!-- <option value="" selected="selected">any district</option> -->
         </select>
         <button id="reset-button" class="search-input" disabled>RESET</button>
       </form>

--- a/scripts/main-built.js
+++ b/scripts/main-built.js
@@ -169,13 +169,14 @@ function filterSelectableDistricts() {
     }).hide();
 
   // if we've now hidden the currently selected district, reset the dropdown
-  let currDistInCurrChamber = $('#district-input')
+  let chamberOfCurrDist = $('#district-input')
     .find(':selected')
-    .attr('chamber')
-    .includes(currChamber);
+    .attr('chamber');
 
-  if (!currDistInCurrChamber) {
-    $('#district-input').val('');
+  if (chamberOfCurrDist) {
+    if (!chamberOfCurrDist.includes(currChamber)) {
+      $('#district-input').val('');
+    }
   }
 }
 
@@ -343,15 +344,29 @@ async function handleStateSelection() {
       );
     });
 
-    // get the names of this state's lower and upper chambers
     chambersMap = {};
+    let lowerDistNums = [];
+    let upperDistNums = [];
     allLegis['representatives'].forEach(legi => {
+      // get the names of this state's lower and upper chambers
       chamberType = legi['role'] === 'Senator' ? 'upper' : 'lower';
-
       if(!Object.keys(chambersMap).includes(chamberType)) {
         chambersMap[chamberType] = legi['office']['district']['district_type']
                                      .replace('Legislative', 'House')  // fix for MD
                                      .trim();
+      }
+
+      // get a list of district numbers in each chamber
+      if (legi['role'] == 'Representative'){
+        lowerDistNums.push(legi['office']['seat_number'])
+      } else if (legi['role'] == 'Senator'){
+        upperDistNums.push(legi['office']['seat_number'])
+      } else {
+        console.warn(
+          `Unable to identify role '${legi['role']}' of legislator ` +
+          `${legi['full_name']} - not adding their district number ` +
+          `to the district drop-down.`
+        );
       }
     });
 
@@ -359,18 +374,6 @@ async function handleStateSelection() {
       $('#chamber-input').append(
         `<option value="${chamber[0]}">${chamber[1]}</option>`
       );
-    });
-
-    // populate the district filter dropdown with a list of districts
-    let lowerDistNums = [];
-    let upperDistNums = [];
-    allLegis['representatives'].forEach(legi => {
-      if (legi['role'] == 'Representative'){
-        lowerDistNums.push(legi['office']['seat_number'])
-      }
-      else if (legi['role'] == 'Senator'){
-        upperDistNums.push(legi['office']['seat_number'])
-      }
     });
 
     let distNums = lowerDistNums.concat(upperDistNums)

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -169,13 +169,14 @@ function filterSelectableDistricts() {
     }).hide();
 
   // if we've now hidden the currently selected district, reset the dropdown
-  let currDistInCurrChamber = $('#district-input')
+  let chamberOfCurrDist = $('#district-input')
     .find(':selected')
-    .attr('chamber')
-    .includes(currChamber);
+    .attr('chamber');
 
-  if (!currDistInCurrChamber) {
-    $('#district-input').val('');
+  if (chamberOfCurrDist) {
+    if (!chamberOfCurrDist.includes(currChamber)) {
+      $('#district-input').val('');
+    }
   }
 }
 
@@ -343,15 +344,29 @@ async function handleStateSelection() {
       );
     });
 
-    // get the names of this state's lower and upper chambers
     chambersMap = {};
+    let lowerDistNums = [];
+    let upperDistNums = [];
     allLegis['representatives'].forEach(legi => {
+      // get the names of this state's lower and upper chambers
       chamberType = legi['role'] === 'Senator' ? 'upper' : 'lower';
-
       if(!Object.keys(chambersMap).includes(chamberType)) {
         chambersMap[chamberType] = legi['office']['district']['district_type']
                                      .replace('Legislative', 'House')  // fix for MD
                                      .trim();
+      }
+
+      // get a list of district numbers in each chamber
+      if (legi['role'] == 'Representative'){
+        lowerDistNums.push(legi['office']['seat_number'])
+      } else if (legi['role'] == 'Senator'){
+        upperDistNums.push(legi['office']['seat_number'])
+      } else {
+        console.warn(
+          `Unable to identify role '${legi['role']}' of legislator ` +
+          `${legi['full_name']} - not adding their district number ` +
+          `to the district drop-down.`
+        );
       }
     });
 
@@ -359,18 +374,6 @@ async function handleStateSelection() {
       $('#chamber-input').append(
         `<option value="${chamber[0]}">${chamber[1]}</option>`
       );
-    });
-
-    // populate the district filter dropdown with a list of districts
-    let lowerDistNums = [];
-    let upperDistNums = [];
-    allLegis['representatives'].forEach(legi => {
-      if (legi['role'] == 'Representative'){
-        lowerDistNums.push(legi['office']['seat_number'])
-      }
-      else if (legi['role'] == 'Senator'){
-        upperDistNums.push(legi['office']['seat_number'])
-      }
     });
 
     let distNums = lowerDistNums.concat(upperDistNums)


### PR DESCRIPTION
For more details on the underlying issue, check out #5.

When the user makes a selection in the 'Select Chamber' drop-down menu, we want the districts in the 'Select District Number' drop-down menu to be limited to districts actually electing officials into that legislative chamber. For example, if a state senate chamber only has 40 seats, we want the district drop-down menu to have the options 1-40. Previously, we were populating this drop-down with district numbers from both the upper and lower legislative chambers, giving users the ability to select districts that didn't exist (usually, a very high district number for the upper chamber).

This PR fixes that issue by making the display status of the `<option>` tags in the district drop-down element responsive to the current selection in the chamber drop-down.