### PR TITLE
Fix responsiveness bug on `Party` column.

### DIFF
--- a/scripts/main-built.js
+++ b/scripts/main-built.js
@@ -190,21 +190,19 @@ function formatTableForBrowserSize() {
   // apply small breakpoint changes
   if($(window).width() <= SMALL_BREAKPOINT){
     $('button.results-cell').html('\>');
-    $('.district-cell, .election-cell').hide();
+    $('.district-cell, .party-cell').hide();
     $('.results-cell > p:nth-child(2)').show();
   } else {
     $('button.results-cell').html('TAKE ACTION');
-    $('.district-cell, .election-cell').show();
+    $('.district-cell, .party-cell').show();
     $('.results-cell > p:nth-child(2)').hide();
   }
 
   // apply mid breakpoint changes
   if($(window).width() <= MID_BREAKPOINT){
     $('#score-header').html('CC SCORE');
-    $('#election-header').html('LAST PRES. RESULT');
   } else {
     $('#score-header').html('CLIMATE CABINET SCORE');
-    $('#election-header').html('LAST PRESIDENTIAL RESULT');
   }
 }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -190,21 +190,19 @@ function formatTableForBrowserSize() {
   // apply small breakpoint changes
   if($(window).width() <= SMALL_BREAKPOINT){
     $('button.results-cell').html('\>');
-    $('.district-cell, .election-cell').hide();
+    $('.district-cell, .party-cell').hide();
     $('.results-cell > p:nth-child(2)').show();
   } else {
     $('button.results-cell').html('TAKE ACTION');
-    $('.district-cell, .election-cell').show();
+    $('.district-cell, .party-cell').show();
     $('.results-cell > p:nth-child(2)').hide();
   }
 
   // apply mid breakpoint changes
   if($(window).width() <= MID_BREAKPOINT){
     $('#score-header').html('CC SCORE');
-    $('#election-header').html('LAST PRES. RESULT');
   } else {
     $('#score-header').html('CLIMATE CABINET SCORE');
-    $('#election-header').html('LAST PRESIDENTIAL RESULT');
   }
 }
 


### PR DESCRIPTION
**the bug**: When the browser width dips below the 'small' breakpoint size, we want the party column to be hidden. Before this commit, this was not happening, and the party column would persist regardless of browser width.

**the fix**: The issue lies in the `formatTableForBrowserSize` function, which was still using the `election-cell` html id to try and hide/ show the columns. We replaced these with `party-cell` and the bug was squashed!