### PR TITLE
Fixes buggy rendering of zero-scoring legislators.

### DIFF
--- a/scripts/main-built.js
+++ b/scripts/main-built.js
@@ -288,7 +288,7 @@ async function handleStateSelection() {
       let distShortcode = legi['office']['district']['shortcode'];
 
       // replace the score value with '-' if NaN
-      let ccScore = legi['cc_score'] ? parseInt(legi['cc_score']) : '-';
+      let ccScore = legi['cc_score'] !== null ? parseInt(legi['cc_score']) : '-';
       let party = legi['party'] || 'Unknown';
 
       // render the row

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -288,7 +288,7 @@ async function handleStateSelection() {
       let distShortcode = legi['office']['district']['shortcode'];
 
       // replace the score value with '-' if NaN
-      let ccScore = legi['cc_score'] ? parseInt(legi['cc_score']) : '-';
+      let ccScore = legi['cc_score'] !== null ? parseInt(legi['cc_score']) : '-';
       let party = legi['party'] || 'Unknown';
 
       // render the row


### PR DESCRIPTION
closes #38

When legislators with scores of 0 were getting rendered to the search module, their scores were showing up as '-' instead of 0. To fix, I corrected some faulty logic treating an score of 0 the same as a non-existent score.
