### PR TITLE
Use absolute url for CTA image url

### DIFF
--- a/scripts/main-built.js
+++ b/scripts/main-built.js
@@ -175,7 +175,7 @@ function formatTableForBrowserSize() {
   if($(window).width() <= SMALL_BREAKPOINT){
     $('.cta-button')
       .html('')
-      .css('background', 'no-repeat center/contain url("../../images/take_action_mobile.png")');
+      .css('background', 'no-repeat center/contain url("/images/take_action_mobile.png")');
     $('.district-cell, .party-cell').hide();
     $('.results-cell > p:nth-child(2)').show();
   } else {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -175,7 +175,7 @@ function formatTableForBrowserSize() {
   if($(window).width() <= SMALL_BREAKPOINT){
     $('.cta-button')
       .html('')
-      .css('background', 'no-repeat center/contain url("../../images/take_action_mobile.png")');
+      .css('background', 'no-repeat center/contain url("/images/take_action_mobile.png")');
     $('.district-cell, .party-cell').hide();
     $('.results-cell > p:nth-child(2)').show();
   } else {


### PR DESCRIPTION
closes #26 

Use absolute URL instead of relative URL so that this works on the production website

cc @karanmotwanipro 